### PR TITLE
[#IOCOM-532] Created a deserializer for due date that is formatted in disparate formats

### DIFF
--- a/src/main/java/it/gov/pagopa/paymentupdater/deserialize/CustomDateTimeDeserializer.java
+++ b/src/main/java/it/gov/pagopa/paymentupdater/deserialize/CustomDateTimeDeserializer.java
@@ -1,0 +1,50 @@
+package it.gov.pagopa.paymentupdater.deserialize;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class CustomDateTimeDeserializer extends JsonDeserializer<LocalDateTime> {
+  /**
+   * The main assumption for this deserializer is that Payment Updater manages
+   * only UTC date times.
+   * It transforms millisecond based timestamps to second based timestamp by
+   * removing all digits above 10th position and it simplifies ISO strings by
+   * removing the timezone since it is UTC based.
+   * @param jsonParser
+   * @param deserializationContext
+   * @return
+   * @throws IOException when a unmanaged format is present
+   */
+  @Override
+  public LocalDateTime deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+    String modelDateTime = jsonParser.getValueAsString();
+    LocalDateTime parsedTimeTime;
+    try {
+      // we parse the local date time from the milliseconds by taking the seconds
+      // and considering UTC timezone
+      parsedTimeTime = LocalDateTime.ofEpochSecond(Long.parseLong(modelDateTime.substring(0,10)), 0, ZoneOffset.UTC);
+    } catch (NumberFormatException nfex) {
+      try {
+        // we parse the local date time removing the timezone
+        parsedTimeTime = LocalDateTime.parse(modelDateTime.substring(0, 23));
+      } catch (Exception ex) {
+        log.error(ex.getMessage());
+        log.error("Found a not managed format for a date: " + modelDateTime);
+        throw ex;
+      }
+    }
+    return parsedTimeTime;
+  }
+}

--- a/src/main/java/it/gov/pagopa/paymentupdater/model/Message.java
+++ b/src/main/java/it/gov/pagopa/paymentupdater/model/Message.java
@@ -15,6 +15,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@SuppressWarnings("java:S116")
 public class Message {
 
 	@Id

--- a/src/main/java/it/gov/pagopa/paymentupdater/model/Message.java
+++ b/src/main/java/it/gov/pagopa/paymentupdater/model/Message.java
@@ -2,6 +2,8 @@ package it.gov.pagopa.paymentupdater.model;
 
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import it.gov.pagopa.paymentupdater.deserialize.CustomDateTimeDeserializer;
 import org.springframework.data.annotation.Id;
 
 import dto.FeatureLevelType;
@@ -10,9 +12,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@Getter 
-@Setter 
-@NoArgsConstructor 
+@Getter
+@Setter
+@NoArgsConstructor
 public class Message {
 
 	@Id
@@ -20,7 +22,8 @@ public class Message {
 	protected String senderServiceId;
 	protected String senderUserId="undefined";
 	protected int timeToLiveSeconds;
-	private LocalDateTime dueDate;
+  @JsonDeserialize(using = CustomDateTimeDeserializer.class)
+  private LocalDateTime dueDate;
 	protected long createdAt;
 	protected boolean isPending = true;
 	protected String content_subject;
@@ -31,5 +34,5 @@ public class Message {
 	protected String content_paymentData_payeeFiscalCode;
 	protected String fiscalCode;
 	protected FeatureLevelType feature_level_type;
-	
+
 }

--- a/src/test/java/it/gov/pagopa/paymentupdater/deserialize/CustomDateTimeDeserializerTest.java
+++ b/src/test/java/it/gov/pagopa/paymentupdater/deserialize/CustomDateTimeDeserializerTest.java
@@ -1,0 +1,75 @@
+package it.gov.pagopa.paymentupdater.deserialize;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import lombok.SneakyThrows;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+
+@RunWith(SpringRunner.class)
+public class CustomDateTimeDeserializerTest {
+  private ObjectMapper mapper;
+  private CustomDateTimeDeserializer deserializer;
+
+  @Before
+  public void setup() {
+    mapper = new ObjectMapper();
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    mapper.registerModule(new ParameterNamesModule());
+    mapper.registerModule(new Jdk8Module());
+    mapper.registerModule(new JavaTimeModule());
+    mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+    deserializer = new CustomDateTimeDeserializer();
+  }
+
+
+  @Test
+  public void ShouldDecodeALocalDateTimeFromANumericString_Ok() {
+    String numericTimestamp = "{\"value\":\"1662588000000\"}";
+    LocalDateTime localDateTime = deserializeLocalDateTimeFromString(numericTimestamp);
+    Assertions.assertEquals(localDateTime, LocalDateTime.parse("2022-09-07T22:00"));
+  }
+
+  @Test
+  public void ShouldDecodeALocalDateTimeFromAnISODateTimeString_Ok() {
+    String numericTimestamp = "{\"value\":\"2023-08-31T12:00:00.000+00:00\"}";
+    LocalDateTime localDateTime = deserializeLocalDateTimeFromString(numericTimestamp);
+    Assertions.assertEquals(localDateTime, LocalDateTime.parse("2023-08-31T12:00:00.000"));
+  }
+
+  @Test
+  public void ShouldThrowForUnrecognizedString_Ok() {
+    String numericTimestamp = "{\"value\":\"notadate\"}";
+    Assertions.assertThrows(RuntimeException.class, () -> deserializeLocalDateTimeFromString(numericTimestamp));
+  }
+
+  @SneakyThrows({JsonParseException.class, IOException.class})
+  private LocalDateTime deserializeLocalDateTimeFromString(String json) {
+    InputStream stream = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
+    JsonParser parser = mapper.getFactory().createParser(stream);
+    DeserializationContext ctxt = mapper.getDeserializationContext();
+    parser.nextToken();
+    parser.nextToken();
+    parser.nextToken();
+    return deserializer.deserialize(parser, ctxt);
+  }
+
+}

--- a/src/test/java/it/gov/pagopa/paymentupdater/deserialize/CustomDateTimeDeserializerTest.java
+++ b/src/test/java/it/gov/pagopa/paymentupdater/deserialize/CustomDateTimeDeserializerTest.java
@@ -46,10 +46,10 @@ public class CustomDateTimeDeserializerTest {
   @Test
   public void ShouldDecodeALocalDateTimeFromStringWithKnownFormat_Ok() {
     Stream.of(new String[][]{
-      {"2023-08-31T12:00:00.000Z", "2023-08-31T12:00"},
-      {"2023-08-31T12:00:00.000+00.00", "2023-08-31T12:00"},
-      {"1662588000000", "2022-09-07T22:00"},
-      {"0", "1970-01-01T00:00"}
+      {"{\"value\":\"2023-08-31T12:00:00.000Z\"}", "2023-08-31T12:00"},
+      {"{\"value\":\"2023-08-31T12:00:00.000+00.00\"}", "2023-08-31T12:00"},
+      {"{\"value\":\"1662588000000\"}", "2022-09-07T22:00"},
+      {"{\"value\":\"0\"}", "1970-01-01T00:00"}
     }).forEach((String[] kv) -> {
       LocalDateTime localDateTime = deserializeLocalDateTimeFromString(kv[0]);
       Assertions.assertEquals(localDateTime, LocalDateTime.parse(kv[1]));

--- a/src/test/java/it/gov/pagopa/paymentupdater/model/PaymentTest.java
+++ b/src/test/java/it/gov/pagopa/paymentupdater/model/PaymentTest.java
@@ -1,0 +1,66 @@
+package it.gov.pagopa.paymentupdater.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import it.gov.pagopa.paymentupdater.utils.JsonModels;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.time.LocalDateTime;
+
+@RunWith(SpringRunner.class)
+
+public class PaymentTest {
+
+  private ObjectMapper mapper;
+
+  @Before
+  public void setup() {
+    mapper = new ObjectMapper();
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    mapper.registerModule(new ParameterNamesModule());
+    mapper.registerModule(new Jdk8Module());
+    mapper.registerModule(new JavaTimeModule());
+    mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+  }
+
+
+  @Test
+  public void ShouldDecodeAPaymentWithUTCDueDate_Ok() throws JsonProcessingException {
+    String paymentJson = JsonModels.getPaymentWithGivenDueDate("2023-08-31T12:00:00.000Z");
+    Payment payment = mapper.readValue(paymentJson, Payment.class);
+    Assertions.assertEquals(payment.getDueDate(), LocalDateTime.parse("2023-08-31T12:00"));
+  }
+
+  @Test
+  public void ShouldDecodeAPaymentWithUTCTimezoneDueDate_Ok() throws JsonProcessingException {
+    String paymentJson = JsonModels.getPaymentWithGivenDueDate("2023-08-31T12:00:00.000+00.00");
+    Payment payment = mapper.readValue(paymentJson, Payment.class);
+    Assertions.assertEquals(payment.getDueDate(), LocalDateTime.parse("2023-08-31T12:00"));
+  }
+
+  @Test
+  public void ShouldDecodeAPaymentWithNumericDueDate_Ok() throws JsonProcessingException {
+    String paymentJson = JsonModels.getPaymentWithGivenDueDate("1662588000000");
+    Payment payment = mapper.readValue(paymentJson, Payment.class);
+    Assertions.assertEquals(payment.getDueDate(), LocalDateTime.parse("2022-09-07T22:00"));
+  }
+
+  @Test
+  public void ShouldFailDecodingAPaymentWithWrongFormatDueDate_Ok() throws JsonProcessingException {
+    String paymentJson = JsonModels.getPaymentWithGivenDueDate("notadate");
+    Assertions.assertThrows(JsonMappingException.class, () -> mapper.readValue(paymentJson, Payment.class));
+  }
+
+}

--- a/src/test/java/it/gov/pagopa/paymentupdater/model/PaymentTest.java
+++ b/src/test/java/it/gov/pagopa/paymentupdater/model/PaymentTest.java
@@ -44,6 +44,7 @@ public class PaymentTest {
       {"2023-08-31T12:00:00.000Z", "2023-08-31T12:00"},
       {"2023-08-31T12:00:00.000+00.00", "2023-08-31T12:00"},
       {"1662588000000", "2022-09-07T22:00"},
+      {"0", "1970-01-01T00:00"}
     }).forEach((String[] kv) -> {
       String paymentJson = JsonModels.getPaymentWithGivenDueDate(kv[0]);
       Payment payment = null;
@@ -58,9 +59,14 @@ public class PaymentTest {
   }
 
   @Test
-  public void ShouldFailDecodingAPaymentWithWrongFormatDueDate_Ok() throws JsonProcessingException {
-    String paymentJson = JsonModels.getPaymentWithGivenDueDate("notadate");
-    Assertions.assertThrows(JsonMappingException.class, () -> mapper.readValue(paymentJson, Payment.class));
+  public void ShouldFailDecodingAPaymentWithWrongFormatDueDate_Ok() {
+    Stream.of(new String[]{
+      "notadatelongversion",
+      "notadate"
+    }).forEach((String v) -> {
+      String paymentJson = JsonModels.getPaymentWithGivenDueDate(v);
+      Assertions.assertThrows(JsonMappingException.class, () -> mapper.readValue(paymentJson, Payment.class));
+    });
   }
 
 }

--- a/src/test/java/it/gov/pagopa/paymentupdater/model/PaymentTest.java
+++ b/src/test/java/it/gov/pagopa/paymentupdater/model/PaymentTest.java
@@ -17,6 +17,8 @@ import org.junit.runner.RunWith;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.stream.Stream;
 
 @RunWith(SpringRunner.class)
 
@@ -37,24 +39,22 @@ public class PaymentTest {
 
 
   @Test
-  public void ShouldDecodeAPaymentWithUTCDueDate_Ok() throws JsonProcessingException {
-    String paymentJson = JsonModels.getPaymentWithGivenDueDate("2023-08-31T12:00:00.000Z");
-    Payment payment = mapper.readValue(paymentJson, Payment.class);
-    Assertions.assertEquals(payment.getDueDate(), LocalDateTime.parse("2023-08-31T12:00"));
-  }
-
-  @Test
-  public void ShouldDecodeAPaymentWithUTCTimezoneDueDate_Ok() throws JsonProcessingException {
-    String paymentJson = JsonModels.getPaymentWithGivenDueDate("2023-08-31T12:00:00.000+00.00");
-    Payment payment = mapper.readValue(paymentJson, Payment.class);
-    Assertions.assertEquals(payment.getDueDate(), LocalDateTime.parse("2023-08-31T12:00"));
-  }
-
-  @Test
-  public void ShouldDecodeAPaymentWithNumericDueDate_Ok() throws JsonProcessingException {
-    String paymentJson = JsonModels.getPaymentWithGivenDueDate("1662588000000");
-    Payment payment = mapper.readValue(paymentJson, Payment.class);
-    Assertions.assertEquals(payment.getDueDate(), LocalDateTime.parse("2022-09-07T22:00"));
+  public void ShouldDecodeAPaymentWithKnownFormatDueDate_Ok() {
+    Stream.of(new String[][]{
+      {"2023-08-31T12:00:00.000Z", "2023-08-31T12:00"},
+      {"2023-08-31T12:00:00.000+00.00", "2023-08-31T12:00"},
+      {"1662588000000", "2022-09-07T22:00"},
+    }).forEach((String[] kv) -> {
+      String paymentJson = JsonModels.getPaymentWithGivenDueDate(kv[0]);
+      Payment payment = null;
+      try {
+        payment = mapper.readValue(paymentJson, Payment.class);
+      } catch (JsonProcessingException e) {
+        // should never happen for well formatted dates
+        throw new RuntimeException(e);
+      }
+      Assertions.assertEquals(payment.getDueDate(), LocalDateTime.parse(kv[1]));
+    });
   }
 
   @Test

--- a/src/test/java/it/gov/pagopa/paymentupdater/utils/JsonModels.java
+++ b/src/test/java/it/gov/pagopa/paymentupdater/utils/JsonModels.java
@@ -1,0 +1,31 @@
+package it.gov.pagopa.paymentupdater.utils;
+
+public class JsonModels {
+
+  public static String getPaymentWithGivenDueDate(String dueDate) {
+    return "{\n" +
+      "  \"readFlag\": false,\n" +
+      "  \"paidFlag\": true,\n" +
+      "  \"insertionDate\": \"2023-08-04T14:24:10.437Z\",\n" +
+      "  \"maxReadMessageSend\": 0,\n" +
+      "  \"maxPaidMessageSend\": 0,\n" +
+      "  \"paidDate\": \"2023-08-20T18:24:18.435Z\",\n" +
+      "  \"rptId\": \"12345678901234567890\",\n" +
+      "  \"senderServiceId\": \"ASDFGHJKL1234567890\",\n" +
+      "  \"senderUserId\": \"ASDFGHJKL1234567890\",\n" +
+      "  \"timeToLiveSeconds\": 3600,\n" +
+      "  \"dueDate\": \"" + dueDate + "\",\n" +
+      "  \"createdAt\": \"1691147078888\",\n" +
+      "  \"isPending\": false,\n" +
+      "  \"content_subject\": \"aSubject\",\n" +
+      "  \"content_type\": \"PAYMENT\",\n" +
+      "  \"content_paymentData_amount\": 2102,\n" +
+      "  \"content_paymentData_noticeNumber\": \"1234567890\",\n" +
+      "  \"content_paymentData_invalidAfterDueDate\": false,\n" +
+      "  \"content_paymentData_payeeFiscalCode\": \"12345678901\",\n" +
+      "  \"fiscalCode\": \"AAAAAA00A00A000A\",\n" +
+      "  \"feature_level_type\": \"STANDARD\",\n" +
+      "  \"_class\": \"it.gov.pagopa.paymentupdater.model.Payment\"\n" +
+      "}";
+  }
+}


### PR DESCRIPTION
#### List of Changes
Added a custom deserializer for dueDate to sanitize its wrong formatting.

#### Motivation and Context
Payment Updater is triggering millions failures because the repository that can't query records inserted before September 2022 because they have a dueDate in numeric format.

#### How Has This Been Tested?
Unit tests.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
